### PR TITLE
Create symbolic instead of hard links to input tomograms

### DIFF
--- a/isonet/protocols/protocol_tomo_reconstruction.py
+++ b/isonet/protocols/protocol_tomo_reconstruction.py
@@ -272,7 +272,7 @@ class ProtIsoNetTomoReconstruction(EMProtocol, ProtTomoBase):
             tomoName = tomo.getTsId()
             tomoLnName = os.path.join(self.tomoPath, tomoName + '.mrc')
             if not os.path.exists(tomoLnName):
-                os.link(tomofn, tomoLnName)
+                os.symlink(tomofn, tomoLnName)
 
         pixel_size = self.inputTomograms.get().getSamplingRate()
 

--- a/isonet/protocols/protocol_tomo_reconstruction.py
+++ b/isonet/protocols/protocol_tomo_reconstruction.py
@@ -33,7 +33,7 @@ import emtable
 from pwem.protocols import EMProtocol
 from pyworkflow.constants import BETA
 from pyworkflow.protocol import params
-from pyworkflow.utils import removeBaseExt
+from pyworkflow.utils import removeBaseExt, path
 
 from tomo.objects import Tomogram
 from tomo.protocols import ProtTomoBase
@@ -272,7 +272,7 @@ class ProtIsoNetTomoReconstruction(EMProtocol, ProtTomoBase):
             tomoName = tomo.getTsId()
             tomoLnName = os.path.join(self.tomoPath, tomoName + '.mrc')
             if not os.path.exists(tomoLnName):
-                os.symlink(tomofn, tomoLnName)
+                path.createLink(tomofn, tomoLnName)
 
         pixel_size = self.inputTomograms.get().getSamplingRate()
 


### PR DESCRIPTION
I was confused thinking that the IsoNet protocol was copying my input tomograms. Turns out that they were actually hard links, which is good since the data does not get duplicated, but is still very confusing IMO. Here I switch `os.link` to `os.symlink`, as symlinks are generally safer, less confusing and more backup-friendly than hard links.
