### PR TITLE
Allow custom activation commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,26 @@ or through the **plugin manager** by launching Scipion and following **Configura
 
   scipion installp -p local/path/to/scipion-em-isonet --devel
 
+**Configuration variables**
+=========================
+
+There are some *optional* variables related to the IsoNet plugin installation. For example, if you have installed IsoNet outside of Scipion, you may define ``ISONET_HOME`` in your ``scipion.conf`` file for specifying an already existing IsoNet installation path. Note that a directory called ``IsoNet`` is expected to exist *within* this path (create a link if necessary):
+
+.. code-block::
+
+    ISONET_HOME = /path/to/my/own/isonet/install/
+
+In the above example, the directory ``/path/to/my/own/isonet/install/IsoNet`` should exist for the plugin to work.
+
+Also, you can use the ``ISONET_ACTIVATION_CMD`` environment variable to indicate an activation command for IsoNet, which can be a conda environment or anything else (e.g. sourcing a script):
+
+.. code-block::
+
+    ISONET_ACTIVATION_CMD = conda activate my-isonet-env
+
+If these variables are not defined, default values will be used that will work with the
+latest version installed through Scipion.
+
 
 ===============
 Buildbot status

--- a/isonet/__init__.py
+++ b/isonet/__init__.py
@@ -43,6 +43,7 @@ class Plugin(pwem.Plugin):
     @classmethod
     def _defineVariables(cls):
         cls._defineEmVar(ISONET_HOME, 'isonet-' + ISONET_VERSION)
+        cls._defineVar(ISONET_ACTIVATION_CMD_VAR, DEFAULT_ISONET_ACTIVATION_CMD)
 
     @classmethod
     def getEnviron(cls):
@@ -56,7 +57,7 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def getIsoNetActivationCmd(cls):
-        return ISONET_ACTIVATION_CMD
+        return cls.getVar(ISONET_ACTIVATION_CMD_VAR)
 
     @classmethod
     def getDependencies(cls):

--- a/isonet/constants.py
+++ b/isonet/constants.py
@@ -38,7 +38,8 @@ def getTrinedModelName(iter):
 
 # IsoNet environment variables
 ISONET_VERSION = '0.2.1'  # This is our made up version
-ISONET_ACTIVATION_CMD = 'conda activate %s' % (getIsoNetEnvName(ISONET_VERSION))
+ISONET_ACTIVATION_CMD_VAR = 'ISONET_ACTIVATION_CMD'
+DEFAULT_ISONET_ACTIVATION_CMD = 'conda activate %s' % (getIsoNetEnvName(ISONET_VERSION))
 
 ISONET_HOME = 'ISONET_HOME'
 

--- a/isonet/protocols/protocol_tomo_reconstruction.py
+++ b/isonet/protocols/protocol_tomo_reconstruction.py
@@ -272,7 +272,7 @@ class ProtIsoNetTomoReconstruction(EMProtocol, ProtTomoBase):
             tomoName = tomo.getTsId()
             tomoLnName = os.path.join(self.tomoPath, tomoName + '.mrc')
             if not os.path.exists(tomoLnName):
-                os.link(tomofn, tomoLnName)
+                os.symlink(tomofn, tomoLnName)
 
         pixel_size = self.inputTomograms.get().getSamplingRate()
 


### PR DESCRIPTION
This PR implements custom activation commands (for example a non-default conda environment outside of Scipion) and updates README for explaining how to use `ISONET_HOME` and `ISONET_ACTIVATION_CMD` config variables.